### PR TITLE
Refine the chinese translation

### DIFF
--- a/json/zhcn/questions-zhcn.json
+++ b/json/zhcn/questions-zhcn.json
@@ -50,7 +50,7 @@
     }
   },
   "scope_of_government1": {
-    "question": "政府规模应当被限制吗？",
+    "question": "政府的管辖范围应当被限制吗？",
     "answers": [
       "yes",
       "no",
@@ -274,7 +274,7 @@
     "nextquestion": {}
   },
   "scope_of_government2": {
-    "question": "政府规模应当被限制吗？",
+    "question": "政府的管辖范围应当被限制吗？",
     "answers": [
       "yes",
       "no",


### PR DESCRIPTION
Actually I'm confused when i met this question for the first time,
then i saw others' issue also mentioned this problem.
as a native Chinese speaker, the original expression "规模" means "scale or size" to me, and it describe something is big or small.
and my suggestion is change it to "管辖范围“. it means the scope that the government can interfere.